### PR TITLE
fixed bug of modal not closing when deleting theme

### DIFF
--- a/backend/routes/api/themes.js
+++ b/backend/routes/api/themes.js
@@ -145,7 +145,7 @@ router.delete('/:themeId', requireAuth, async (req, res) => {
     if (posts.length > 0) {
         res.status(400);
         return res.json({
-            message: "Cannot delete theme that is in use."
+            error: "Cannot delete theme that is in use."
         })
     }
 

--- a/frontend/src/components/Profile/Profile.jsx
+++ b/frontend/src/components/Profile/Profile.jsx
@@ -11,7 +11,7 @@ function Profile() {
     const dispatch = useDispatch();
     const user = useSelector((state) => state.session.user);
     const themes = useSelector((state) => state.themes.byUser[user?.id])
-    const [showThemes, setShowThemes] = useState(false);
+    const [showThemes, setShowThemes] = useState(true);
 
     useEffect(() => {
         dispatch(getUserIdThemesThunk(user?.id));

--- a/frontend/src/components/Themes/DeleteThemeModal.jsx
+++ b/frontend/src/components/Themes/DeleteThemeModal.jsx
@@ -11,11 +11,10 @@ function DeleteThemeModal({ theme, userId }) {
 
     const handleConfirmSubmit = async (e) => {
         e.preventDefault();
-        setErrors({});
 
         const res = await dispatch(deleteThemeThunk(theme.id, userId))
 
-        if (res.message) {
+        if (res.error) {
             setErrors(res);
         } else {
             await dispatch(getUserIdThemesThunk(userId));
@@ -33,8 +32,8 @@ function DeleteThemeModal({ theme, userId }) {
         <div className='deleteTheme modalContainer'>
             <h1>Confirm Delete</h1>
 
-            {errors.message && (
-                <p className='errors'>{errors.message}</p>
+            {errors.error && (
+                <p className='errors'>{errors.error}</p>
             )}
 
             <p>

--- a/frontend/src/redux/themes.js
+++ b/frontend/src/redux/themes.js
@@ -124,7 +124,6 @@ export const deleteThemeThunk = (themeId, userId) => async (dispatch) => {
         throw res;
     } catch (e) {
         const data = await e.json();
-        console.log("res?", data);
         return data;
     }
 };


### PR DESCRIPTION
previous error handling was keying into "message" for error (error in question being when you try to delete a theme that is currently being used). Changed the keyname to "error" instead.